### PR TITLE
Add toggle to flip song info

### DIFF
--- a/src/main/kotlin/dev/tricht/gamesense/Main.kt
+++ b/src/main/kotlin/dev/tricht/gamesense/Main.kt
@@ -28,6 +28,7 @@ var preferences: Preferences = Preferences.userNodeForPackage(Main::class.java)
 var clockEnabled = preferences.get("clock", "true").toBoolean()
 var clockIconEnabled = preferences.get("clockIcon", "true")!!.toBoolean()
 var volumeEnabled = preferences.get("volume", "true").toBoolean()
+var songInfoFlipEnabled = preferences.get("songInfoFlip", "false").toBoolean()
 
 fun main() {
     SystemTray.setup()
@@ -105,42 +106,7 @@ class Main {
                 println("Failed to add volume handler, error: " + response.errorBody()?.string())
                 exitProcess(1)
             }
-            val songHandler = EventRegistration(
-                GAME_NAME,
-                SONG_EVENT,
-                listOf(
-                    Handler(
-                        listOf(
-                            MultiLine(
-                                listOf(
-                                    HandlerData(
-                                        contextFrameKey = "artist"
-                                    ),
-                                    HandlerData(
-                                        contextFrameKey = "song"
-                                    )
-                                ),
-                                23
-                            )
-                        )
-                    )
-                ),
-                listOf(
-                    DataField(
-                        "artist",
-                        "Artist"
-                    ),
-                    DataField(
-                        "song",
-                        "Song"
-                    )
-                )
-            )
-            response = client.addEvent(songHandler).execute()
-            if (!response.isSuccessful) {
-                println("Failed to add song handler, error: " + response.errorBody()?.string())
-                exitProcess(1)
-            }
+            registerSongHandler(client)
         }
 
         fun registerClockHandler(client: ApiClient) {
@@ -161,6 +127,84 @@ class Main {
             if (!response.isSuccessful) {
                 println("Failed to add clock icon handler, error: " + response.errorBody()?.string())
                 exitProcess(1)
+            }
+        }
+
+        fun registerSongHandler(client: ApiClient) {
+            if(songInfoFlipEnabled) {
+                val songHandler = EventRegistration(
+                    GAME_NAME,
+                    SONG_EVENT,
+                    listOf(
+                        Handler(
+                            listOf(
+                                MultiLine(
+                                    listOf(
+                                        HandlerData(
+                                            contextFrameKey = "artist"
+                                        ),
+                                        HandlerData(
+                                            contextFrameKey = "song"
+                                        )
+                                    ),
+                                    23
+                                )
+                            )
+                        )
+                    ),
+                    listOf(
+                        DataField(
+                            "song",
+                            "Song"
+                        ),
+                        DataField(
+                            "artist",
+                            "Artist"
+                        )
+                    )
+                )
+                val response = client.addEvent(songHandler).execute()
+                if (!response.isSuccessful) {
+                    println("Failed to add song handler, error: " + response.errorBody()?.string())
+                    exitProcess(1)
+                }
+            } else {
+                val songHandler = EventRegistration(
+                    GAME_NAME,
+                    SONG_EVENT,
+                    listOf(
+                        Handler(
+                            listOf(
+                                MultiLine(
+                                    listOf(
+                                        HandlerData(
+                                            contextFrameKey = "song"
+                                        ),
+                                        HandlerData(
+                                            contextFrameKey = "artist"
+                                        )
+                                    ),
+                                    23
+                                )
+                            )
+                        )
+                    ),
+                    listOf(
+                        DataField(
+                            "song",
+                            "Song"
+                        ),
+                        DataField(
+                            "artist",
+                            "Artist"
+                        )
+                    )
+                )
+                val response = client.addEvent(songHandler).execute()
+                if (!response.isSuccessful) {
+                    println("Failed to add song handler, error: " + response.errorBody()?.string())
+                    exitProcess(1)
+                }
             }
         }
 

--- a/src/main/kotlin/dev/tricht/gamesense/SystemTray.kt
+++ b/src/main/kotlin/dev/tricht/gamesense/SystemTray.kt
@@ -44,11 +44,19 @@ class SystemTray {
                 preferences.put("volume", menuItem.state.toString())
                 volumeEnabled = menuItem.state
             }
+            val songInfoFlip = CheckboxMenuItem("Flip song title and artist")
+            songInfoFlip.addItemListener {
+                val menuItem = it.source as CheckboxMenuItem
+                preferences.put("songInfoFlip", menuItem.state.toString())
+                songInfoFlipEnabled = menuItem.state
+                Main.registerSongHandler(client!!)
+            }
             volume.state = preferences.get("volume", "true").toBoolean()
             menu.add(title)
             menu.add(volume)
             menu.add(clock)
             menu.add(clockIcon)
+            menu.add(songInfoFlip)
             menu.add(tickRate)
             menu.add(exit)
             val trayIconImage = ImageIO.read(Main::class.java.classLoader.getResource("icon.png"))


### PR DESCRIPTION
I've noticed the artist name is shown above the artist name, while in Spotify and in the Windows UI the song name is above the artist name.

Examples:

Spotify:
![image](https://user-images.githubusercontent.com/29610114/108425253-d3dce380-71ff-11eb-886a-786be6212fec.png)


Windows:
![image](https://user-images.githubusercontent.com/29610114/108425281-db9c8800-71ff-11eb-8664-07341ba17032.png)


I thought this would be nice to implement, so I did a quick version. I tried to keep the control flow similar to @wubli 's clock toggle, but of course if you think anything should be changed please let me know!