### PR TITLE
Added ability to disable the song icon

### DIFF
--- a/src/main/kotlin/dev/tricht/gamesense/Main.kt
+++ b/src/main/kotlin/dev/tricht/gamesense/Main.kt
@@ -100,7 +100,7 @@ class Main {
                                             contextFrameKey = "song"
                                         )
                                     ),
-                                    23
+                                    if (preferences.get("songIcon", "true")!!.toBoolean()) 23 else 0
                                 )
                             )
                         )
@@ -137,7 +137,7 @@ class Main {
                                             contextFrameKey = "artist"
                                         )
                                     ),
-                                    23
+                                    if (preferences.get("songIcon", "true")!!.toBoolean()) 23 else 0
                                 )
                             )
                         )

--- a/src/main/kotlin/dev/tricht/gamesense/SystemTray.kt
+++ b/src/main/kotlin/dev/tricht/gamesense/SystemTray.kt
@@ -32,6 +32,7 @@ class SystemTray {
                 createSettingMenuItem("Display clock periodically", "clockPeriodically", false),
                 createSettingMenuItem("Enable volume slider", "volume"),
                 createSettingMenuItem("Enable song information", "songInfo"),
+                createSettingMenuItem("Enable song icon", "songIcon"),
                 createSettingMenuItem("Flip song title and artist", "songInfoFlip", false),
                 tickRate,
                 exit

--- a/src/main/kotlin/dev/tricht/gamesense/events/EventProducer.kt
+++ b/src/main/kotlin/dev/tricht/gamesense/events/EventProducer.kt
@@ -13,7 +13,7 @@ import java.util.*
 class EventProducer : TimerTask() {
     private val dataFetcher = WindowsDataFetcher()
     private var client = ApiClientFactory().createApiClient()
-    private val dateFormat = DateFormat.getTimeInstance(0)
+    private val dateFormat = DateFormat.getTimeInstance()
     private var volume: Int? = null
     private var waitTicks = 0
     private var displayClockPeriodically = 0

--- a/src/main/kotlin/dev/tricht/gamesense/events/EventProducer.kt
+++ b/src/main/kotlin/dev/tricht/gamesense/events/EventProducer.kt
@@ -13,7 +13,7 @@ import java.util.*
 class EventProducer : TimerTask() {
     private val dataFetcher = WindowsDataFetcher()
     private var client = ApiClientFactory().createApiClient()
-    private val dateFormat = DateFormat.getTimeInstance()
+    private val dateFormat = DateFormat.getTimeInstance(0)
     private var volume: Int? = null
     private var waitTicks = 0
     private var displayClockPeriodically = 0

--- a/src/main/kotlin/dev/tricht/gamesense/model/ScrollingText.kt
+++ b/src/main/kotlin/dev/tricht/gamesense/model/ScrollingText.kt
@@ -8,7 +8,7 @@ var preferences: Preferences = Preferences.userNodeForPackage(ScrollingText::cla
 
 data class ScrollingText(
     var _text: String,
-    var MAX_DISPLAY_TEXT_LENGTH: Int = if (preferences.get("clockIcon", "true")!!.toBoolean()) 21 else 12
+    var MAX_DISPLAY_TEXT_LENGTH: Int = if (preferences.get("songIcon", "true")!!.toBoolean()) 21 else 12
 ) {
 
     var text = _text

--- a/src/main/kotlin/dev/tricht/gamesense/model/ScrollingText.kt
+++ b/src/main/kotlin/dev/tricht/gamesense/model/ScrollingText.kt
@@ -1,14 +1,15 @@
 package dev.tricht.gamesense.model
 
+import dev.tricht.gamesense.Main
 import dev.tricht.gamesense.Tick
+import java.util.prefs.Preferences
+
+var preferences: Preferences = Preferences.userNodeForPackage(ScrollingText::class.java)
 
 data class ScrollingText(
-    var _text: String
+    var _text: String,
+    var MAX_DISPLAY_TEXT_LENGTH: Int = if (preferences.get("clockIcon", "true")!!.toBoolean()) 21 else 12
 ) {
-
-    companion object {
-        const val MAX_DISPLAY_TEXT_LENGTH = 12
-    }
 
     var text = _text
     get() {
@@ -31,8 +32,8 @@ data class ScrollingText(
     private var originalText = _text
 
     init {
-        if (_text.length >= MAX_DISPLAY_TEXT_LENGTH) {
-            text = "$_text "
+        if (_text.length > MAX_DISPLAY_TEXT_LENGTH) {
+            text = "$_text | "
             originalText = "$_text "
         }
     }

--- a/src/main/kotlin/dev/tricht/gamesense/model/ScrollingText.kt
+++ b/src/main/kotlin/dev/tricht/gamesense/model/ScrollingText.kt
@@ -8,7 +8,7 @@ var preferences: Preferences = Preferences.userNodeForPackage(ScrollingText::cla
 
 data class ScrollingText(
     var _text: String,
-    var MAX_DISPLAY_TEXT_LENGTH: Int = if (preferences.get("songIcon", "true")!!.toBoolean()) 21 else 12
+    var MAX_DISPLAY_TEXT_LENGTH: Int = if (preferences.get("songIcon", "true")!!.toBoolean()) 12 else 21
 ) {
 
     var text = _text


### PR DESCRIPTION
Required a couple simple changes and a more significant one to the scrolling text class.  This gives the song title and artist name 21 characters of space instead of 12, reducing the need for text scrolling to show the complete text.